### PR TITLE
Correct ManagementPlaneTransportFc (fixes issue#56)

### DIFF
--- a/spec/InformationStructure/schemas/09_NetworkControlDomain.yaml
+++ b/spec/InformationStructure/schemas/09_NetworkControlDomain.yaml
@@ -67,7 +67,7 @@ network-control-domain:
                 - 'management-plane-transport'
             forwarding-construct:
               type: array
-              x-key: mount-name
+              x-key: forwarding-construct-name
               items:
                 type: object
                 description: 'ForwardingConstruct - see 88_ManagementPlaneTransportConnection.yaml'

--- a/spec/InformationStructure/schemas/88_ManagementPlaneTransportConnection.yaml
+++ b/spec/InformationStructure/schemas/88_ManagementPlaneTransportConnection.yaml
@@ -1,14 +1,14 @@
 forwarding-construct:
   type: array
-  x-key: mount-name
+  x-key: forwarding-construct-name
   items:
     type: object
     required:
-      - mount-name
+      - forwarding-construct-name
       - fctp
       - route
     properties:
-      mount-name:
+      forwarding-construct-name:
         type: string
         description: >
           'MountName

--- a/spec/InformationStructure/schemas/88_ManagementPlaneTransportConnection.yaml
+++ b/spec/InformationStructure/schemas/88_ManagementPlaneTransportConnection.yaml
@@ -11,7 +11,7 @@ forwarding-construct:
       forwarding-construct-name:
         type: string
         description: >
-          'MountName
+          'deviceName
           candidate: from [DDM://v1/establish-management-plane-transport$request.body#device-name]
           running: from candidate
           operational: from [module OperationalManagementPlaneTransportList]'
@@ -63,12 +63,15 @@ forwarding-construct:
           type: object
           required:
             - local-id
-            - _link
+            - _links
           properties:
             local-id:
               type: string
               description: >
-                'Identifier that is unique within the list of Routes'
+                'Identifier that is unique within the list of Routes
+                candidate:
+                running: from candidate
+                operational: from running; entire Route to be deleted, if one of the referenced Links does not exist in operationalDS'
             _links:
               type: array
               minItems: 2


### PR DESCRIPTION
The key attribute of the ManagementPlaneTransportFc is named according to its value, but the name should relate to its type of object.


@PrathibaJee: Please review, merge into v1.0.0_spec, delete branch thorsten/56 and close issue#56, if everything fine.