### PR TITLE
Update DomainController and ErrorCode schemas (fixes #58)

### DIFF
--- a/spec/InformationStructure/initialData/05_ErrorCodeData.yaml
+++ b/spec/InformationStructure/initialData/05_ErrorCodeData.yaml
@@ -1,0 +1,85 @@
+error-code:
+  # The following definitions have been transferred from somewhere else
+  # ApplicationOwner is free to delete and modify as wished
+  # (Please delete this comment after reading)
+
+  - error-code: 630
+    description: 'Device does not answer on Ping'
+    _implementation-function:
+  - error-code: 631
+    description: 'Device does not answer on SNMP request'
+    _implementation-function:
+  - error-code: 632
+    description: 'Addressed resource/service does not exist on the device'
+    _implementation-function:
+  - error-code: 633
+    description: 'Authentication at the device failed'
+    _implementation-function:
+
+  - error-code: 640
+    description: 'MediatorVM (MIM) does not answer on Ping'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually. 
+  - error-code: 641
+    description: 'MediatorVM (MIM) does not answer on HTTP requests'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually. 
+  - error-code: 642
+    description: 'Addressed management resource/service does not exist on the MediatorVM (MIM)'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually. 
+  - error-code: 643
+    description: 'Number of instances in the MediatorVM (MIM) is not compliance with the associated template'
+    _implementation-function: 'p1-implementation-existing-mediator-vms-complying-with-template-definition'
+
+  - error-code: 645
+    description: 'MediatorProcess is not configured'
+    _implementation-function:
+  - error-code: 646
+    description: 'MediatorProcess is not active'
+    _implementation-function: # [Prathiba] Existing process shall be deleted and new process shall be instantiated ? or no action will be taken ?
+  - error-code: 647
+    description: 'MediatorProcess does not answer on HTTP requests'
+    _implementation-function: # [Prathiba] This shall be removed as MediatorProcess will not usually answer on the HTTP layer. MediatorProcess shall be addressed only by Netconf protocol.
+
+  - error-code: 650
+    description: 'Controller does not answer on Ping'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
+  - error-code: 651
+    description: 'Controller does not answer on HTTP request'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
+  - error-code: 652
+    description: 'Addressed management resource/service does not exist on the controller'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
+  - error-code: 653
+    description: 'Authentication at the controller failed'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
+
+  - error-code: 655
+    description: 'MountPoint is not configured'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
+  - error-code: 656
+    description: 'MountPoint is not in connected state'
+    _implementation-function: 
+  - error-code: 657
+    description: 'MountPoint does not answer on HTTP requests'
+    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
+
+  - error-code:
+    description:
+    _implementation-function:
+  - error-code:
+    description:
+    _implementation-function:
+  - error-code:
+    description:
+    _implementation-function:
+  - error-code:
+    description:
+    _implementation-function:
+  - error-code:
+    description:
+    _implementation-function:
+  - error-code:
+    description:
+    _implementation-function:
+  - error-code:
+    description:
+    _implementation-function:

--- a/spec/InformationStructure/schemas/00_DomainController.yaml
+++ b/spec/InformationStructure/schemas/00_DomainController.yaml
@@ -49,4 +49,4 @@ domain-controller:
         type: object
         description: >
           'NetworkControlDomain for CandidateDS, RunningDS, OperationalDS or StartupDS - see 09_NetworkControlDomain.yaml
-          Four identical information structures describing candidate, startup, running and operational data store according to NMDA concept'
+          Up to four identical information structures describing candidate, running, operational and potentially startup data store according to NMDA concept'

--- a/spec/InformationStructure/schemas/05_ErrorCode.yaml
+++ b/spec/InformationStructure/schemas/05_ErrorCode.yaml
@@ -1,7 +1,7 @@
 error-code:
   type: array
   x-key: error-code
-  description: 'List of ErrorCodes with descriptions and corresponding ImplementationFunction'
+  description: 'List of ErrorCodes with their description and corresponding ImplementationFunction'
   items:
     type: object
     required:
@@ -23,90 +23,6 @@ error-code:
         type: string
         description: >
           'Only applicable for internal codes
+          Reference towards an entry in the list of Functions
+          Only Functions for executing a change on the managed elements are allowed to be referenced
           Ideally, each internal code would be handled by a function'
-example:
-
-  # The following definitions have been transferred from somewhere else
-  # ApplicationOwner is free to delete and modify as wished
-  # (Please delete this comment after reading)
-
-  - error-code: 630
-    description: 'Device does not answer on Ping'
-    _implementation-function:
-  - error-code: 631
-    description: 'Device does not answer on SNMP request'
-    _implementation-function:
-  - error-code: 632
-    description: 'Addressed resource/service does not exist on the device'
-    _implementation-function:
-  - error-code: 633
-    description: 'Authentication at the device failed'
-    _implementation-function:
-
-  - error-code: 640
-    description: 'MediatorVM (MIM) does not answer on Ping'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually. 
-  - error-code: 641
-    description: 'MediatorVM (MIM) does not answer on HTTP requests'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually. 
-  - error-code: 642
-    description: 'Addressed management resource/service does not exist on the MediatorVM (MIM)'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually. 
-  - error-code: 643
-    description: 'Number of instances in the MediatorVM (MIM) is not compliance with the associated template'
-    _implementation-function: 'p1-implementation-existing-mediator-vms-complying-with-template-definition'
-
-  - error-code: 645
-    description: 'MediatorProcess is not configured'
-    _implementation-function:
-  - error-code: 646
-    description: 'MediatorProcess is not active'
-    _implementation-function: # [Prathiba] Existing process shall be deleted and new process shall be instantiated ? or no action will be taken ?
-  - error-code: 647
-    description: 'MediatorProcess does not answer on HTTP requests'
-    _implementation-function: # [Prathiba] This shall be removed as MediatorProcess will not usually answer on the HTTP layer. MediatorProcess shall be addressed only by Netconf protocol.
-
-  - error-code: 650
-    description: 'Controller does not answer on Ping'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
-  - error-code: 651
-    description: 'Controller does not answer on HTTP request'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
-  - error-code: 652
-    description: 'Addressed management resource/service does not exist on the controller'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
-  - error-code: 653
-    description: 'Authentication at the controller failed'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
-
-  - error-code: 655
-    description: 'MountPoint is not configured'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
-  - error-code: 656
-    description: 'MountPoint is not in connected state'
-    _implementation-function: 
-  - error-code: 657
-    description: 'MountPoint does not answer on HTTP requests'
-    _implementation-function: 'NA' # [Prathiba] From DDM automatically no action shall be taken. Alarm exist until problem corrected manually.
-
-  - error-code:
-    description:
-    _implementation-function:
-  - error-code:
-    description:
-    _implementation-function:
-  - error-code:
-    description:
-    _implementation-function:
-  - error-code:
-    description:
-    _implementation-function:
-  - error-code:
-    description:
-    _implementation-function:
-  - error-code:
-    description:
-    _implementation-function:
-  - error-code:
-    description:
-    _implementation-function:


### PR DESCRIPTION
DomainController schema:
- The StartupDS does not necessarily require a separate NetworkControlDomain, if e.g. RunningDS is implemented as a permanent data storage.
A description needs to be changed accordingly.

ErrorCode schema:
- Minor editorial changes on two descriptions, mainly for clarification purposes.
- Error codes actually needed for implementing the application shall no longer be defined as examples in the schema (05_ErrorCode.yaml), but in a separate file (./initialData/05_ErrorCodeData.yaml)

@PrathibaJee: Please review, merge into v1.0.0_spec, delete branch thorsten/58 and close issue#58, if everything fine.